### PR TITLE
Improve quiz interface

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -64,6 +64,9 @@
 
     <div class="quiz-container bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
         <div id="quiz-header" class="mb-6 relative">
+            <div class="absolute top-0 left-0">
+                <button id="open-review-btn" class="text-blue-600 underline">Review</button>
+            </div>
             <h1 id="quiz-title" class="text-3xl font-bold text-gray-800 dark:text-gray-100 text-center pr-12">Practice Quiz</h1>
             <p class="text-gray-600 dark:text-gray-300 mt-2 text-center">Test your knowledge with these 100 questions.</p>
             <div class="absolute top-0 right-0 text-right">
@@ -97,6 +100,26 @@
             <div id="flagged-list" class="space-y-2"></div>
             <div class="text-center mt-6">
                 <button id="resume-btn" class="bg-blue-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-600 transition-colors dark:bg-blue-600 dark:hover:bg-blue-700">Continue Quiz</button>
+            </div>
+        </div>
+
+        <div id="review-overview" class="hidden">
+            <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4 text-center">Review Questions</h2>
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-left border-collapse">
+                    <thead>
+                        <tr>
+                            <th class="py-2 px-3 border-b">#</th>
+                            <th class="py-2 px-3 border-b">Answered</th>
+                            <th class="py-2 px-3 border-b">Flagged</th>
+                            <th class="py-2 px-3 border-b"></th>
+                        </tr>
+                    </thead>
+                    <tbody id="review-table-body"></tbody>
+                </table>
+            </div>
+            <div class="text-center mt-6">
+                <button id="close-review-btn" class="bg-blue-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-600 transition-colors dark:bg-blue-600 dark:hover:bg-blue-700">Return to Quiz</button>
             </div>
         </div>
     </div>
@@ -158,6 +181,10 @@
         const quizHeader = document.getElementById('quiz-header');
         const resultsContainer = document.getElementById('results');
         const reviewPage = document.getElementById('review-page');
+        const reviewOverview = document.getElementById('review-overview');
+        const reviewTableBody = document.getElementById('review-table-body');
+        const openReviewBtn = document.getElementById('open-review-btn');
+        const closeReviewBtn = document.getElementById('close-review-btn');
         const flaggedList = document.getElementById('flagged-list');
         const resumeBtn = document.getElementById('resume-btn');
         const restartBtn = document.getElementById('restart-btn');
@@ -267,14 +294,13 @@
                 `).join('');
             }
 
-            const flagIcon = flaggedQuestions[currentQuestionIndex] ? '🚩' : '🏳️';
+            const flagText = flaggedQuestions[currentQuestionIndex] ? 'Unflag Question' : 'Flag Question';
 
             quizBody.innerHTML = `
                 <div class="mb-4 flex justify-between items-start">
-                    <p class="text-lg font-semibold text-gray-700 mr-4 dark:text-gray-100">${currentQuestion.question.replace(/\n/g, '<br>')}</p>
+                    <p class="text-lg font-semibold text-gray-700 mr-4 dark:text-gray-100 break-words whitespace-pre-wrap">${currentQuestionIndex + 1}. ${currentQuestion.question.replace(/\n/g, '<br>')}</p>
                     <div class="space-x-2">
-                        <button id="answer-btn" class="px-2 py-1 bg-gray-200 rounded" title="See Answer">See Answer</button>
-                        <button id="flag-btn" class="text-xl">${flagIcon}</button>
+                        <button id="flag-btn" class="px-2 py-1 bg-yellow-200 rounded">${flagText}</button>
                     </div>
                 </div>
                 <div id="options-container" class="space-y-3">
@@ -284,6 +310,9 @@
                    <button id="back-btn" class="bg-gray-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-gray-600 transition-colors dark:bg-gray-600 dark:hover:bg-gray-700">Back</button>
                    <p class="text-sm text-gray-500">Question ${currentQuestionIndex + 1} of ${quizData.length}</p>
                    <button id="next-btn" class="bg-blue-500 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-600 transition-colors dark:bg-blue-600 dark:hover:bg-blue-700">Next</button>
+                </div>
+                <div class="mt-2 flex justify-end">
+                    <button id="answer-btn" class="px-2 py-1 bg-gray-200 rounded" title="See Answer">See Answer</button>
                 </div>
             `;
             
@@ -425,6 +454,31 @@
             };
         }
 
+        function renderReviewTable() {
+            reviewTableBody.innerHTML = quizData.map((q, i) => {
+                const answered = userSelections[i] && (Array.isArray(userSelections[i]) ? userSelections[i].length > 0 : true);
+                const flagged = flaggedQuestions[i];
+                return `
+                    <tr>
+                        <td class="py-2 px-3 border-b">${i + 1}</td>
+                        <td class="py-2 px-3 border-b">${answered ? 'Yes' : 'No'}</td>
+                        <td class="py-2 px-3 border-b">${flagged ? 'Yes' : 'No'}</td>
+                        <td class="py-2 px-3 border-b"><button class="goto-question-btn text-blue-600 underline" data-index="${i}">Go</button></td>
+                    </tr>
+                `;
+            }).join('');
+
+            reviewOverview.querySelectorAll('.goto-question-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    currentQuestionIndex = parseInt(e.currentTarget.dataset.index, 10);
+                    reviewOverview.classList.add('hidden');
+                    quizBody.classList.remove('hidden');
+                    quizHeader.classList.remove('hidden');
+                    showQuestion();
+                });
+            });
+        }
+
         function showResults() {
             clearInterval(timerInterval);
             clearSavedQuizState();
@@ -544,6 +598,20 @@
         restartBtn.addEventListener('click', () => {
             clearSavedQuizState();
             startQuiz();
+        });
+        openReviewBtn.addEventListener('click', () => {
+            clearInterval(timerInterval);
+            renderReviewTable();
+            reviewOverview.classList.remove('hidden');
+            quizBody.classList.add('hidden');
+            quizHeader.classList.add('hidden');
+        });
+        closeReviewBtn.addEventListener('click', () => {
+            reviewOverview.classList.add('hidden');
+            quizBody.classList.remove('hidden');
+            quizHeader.classList.remove('hidden');
+            startTimer(remainingTime);
+            showQuestion();
         });
         
         // --- Initial Start ---


### PR DESCRIPTION
## Summary
- show question numbers and break long lines
- replace flag icon with "Flag Question" text
- move answer button below navigation buttons
- add a Review button to display all questions with answered/flagged status

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_685d27d481e48332a74bf2eeda051546